### PR TITLE
Store popout screen coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # PF2e-Popout
+
+Helpers for opening browser windows at user-defined screen coordinates.
+
+## Usage
+
+```javascript
+import { savePopoutPosition, openPopout } from './popout.js';
+
+// Store preferred coordinates, e.g. on a second monitor.
+savePopoutPosition(1920, 100);
+
+// Open the window using the saved coordinates with automatic fallback.
+openPopout('https://example.com', { width: 600, height: 400 });
+```
+
+`openPopout` verifies that the saved `left`/`top` fit within the current
+available screen space. If the target monitor is not connected, the window
+falls back to the primary screen.
+

--- a/popout.js
+++ b/popout.js
@@ -1,0 +1,49 @@
+const STORAGE_KEY = 'pf2e-popout-coordinates';
+
+/**
+ * Persist coordinates for where the pop-out window should appear.
+ * @param {number} left - The x-coordinate of the window.
+ * @param {number} top - The y-coordinate of the window.
+ */
+export function savePopoutPosition(left, top) {
+  if (typeof left !== 'number' || typeof top !== 'number') return;
+  const data = { left, top };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+/**
+ * Open a new window using the stored coordinates. If the coordinates are
+ * outside of the available screen space (e.g. a second monitor is not
+ * connected), the window falls back to the primary monitor.
+ *
+ * @param {string} url - URL to load in the new window.
+ * @param {object} [options={}] - Optional additional features for window.open.
+ * @param {string} [options.name] - Name of the window.
+ * @param {number} [options.width] - Desired width of the window.
+ * @param {number} [options.height] - Desired height of the window.
+ * @param {number} [options.left] - Fallback left coordinate.
+ * @param {number} [options.top] - Fallback top coordinate.
+ * @returns {Window|null} - Reference to the opened window or null on failure.
+ */
+export function openPopout(url, options = {}) {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  let { left, top } = stored ? JSON.parse(stored) : {};
+
+  const availWidth = window.screen?.availWidth ?? window.innerWidth;
+  const availHeight = window.screen?.availHeight ?? window.innerHeight;
+
+  if (
+    typeof left !== 'number' || typeof top !== 'number' ||
+    left < 0 || top < 0 || left > availWidth || top > availHeight
+  ) {
+    // Fallback to provided options or origin screen if coordinates are invalid.
+    left = options.left ?? 0;
+    top = options.top ?? 0;
+  }
+
+  const features = [`left=${left}`, `top=${top}`];
+  if (options.width) features.push(`width=${options.width}`);
+  if (options.height) features.push(`height=${options.height}`);
+
+  return window.open(url, options.name ?? '', features.join(','));
+}


### PR DESCRIPTION
## Summary
- add helpers to persist screen coordinates for pop-out windows
- open windows at stored coordinates with fallback to primary monitor
- document usage of new popout utilities

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b6fb29908327acd1b9544a7df0f3