### PR TITLE
feat: add pop-out button hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # PF2e-Popout
+
+Adds a monitor icon button to PF2e actor sheets, the combat tracker, and journal sheets.
+Clicking the button pops the sheet out into a separate window.

--- a/src/popout-buttons.js
+++ b/src/popout-buttons.js
@@ -1,0 +1,35 @@
+const HOOKS = [
+  'renderActorSheetPF2e',
+  'renderCombatTracker',
+  'renderJournalSheet',
+];
+
+const ICON_HTML = '<i class="fas fa-tv"></i>';
+
+function addPopoutButton(app, html) {
+  const titleElement = html.closest('.app').find('header .window-title');
+  const buttonClass = 'popout-header-button';
+  if (titleElement.length === 0 || titleElement.siblings(`.${buttonClass}`).length) {
+    return;
+  }
+
+  const button = $(`<a class="${buttonClass}" title="Pop out">${ICON_HTML}</a>`);
+  button.on('click', event => {
+    event.preventDefault();
+    if (typeof app.popOut === 'function') {
+      app.popOut();
+    } else {
+      app.render(true, { popout: true });
+    }
+  });
+
+  const headerButtons = html.closest('.app').find('header .header-buttons');
+  if (headerButtons.length) {
+    headerButtons.prepend(button);
+  } else {
+    titleElement.parent().append(button);
+  }
+}
+
+HOOKS.forEach(hook => Hooks.on(hook, addPopoutButton));
+


### PR DESCRIPTION
## Summary
- add shared hook logic inserting a monitor icon button into PF2e actor sheets, combat tracker, and journal sheets
- clicking the button opens the sheet in a pop-out window

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b6f681688327bff64454041b91d8