### PR TITLE
Add Foundry module manifest and documentation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,13 +1,18 @@
 module.exports = {
   env: {
     node: true,
+    browser: true,
     es2021: true,
     jest: true,
   },
   extends: ['eslint:recommended', 'prettier'],
   parserOptions: {
     ecmaVersion: 'latest',
-    sourceType: 'script',
+    sourceType: 'module',
+  },
+  globals: {
+    $: 'readonly',
+    Hooks: 'readonly',
   },
   rules: {},
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 0.1.0 - 2025-08-22
 
 - Initial release with basic popout function, linting, formatting, and tests.
+
+## 0.1.1 - 2025-08-22
+
+- Added `module.json` Foundry manifest and documented manifest URL for releases.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ formatting, and testing setup.
 2. Run `npm install` to install dependencies.
 3. Use `npm test` to run tests.
 4. Use `npm run lint` to lint the code and `npm run format` to apply Prettier formatting.
+5. For Foundry VTT, install the module by pointing Foundry to the [manifest file](https://raw.githubusercontent.com/yourname/PF2e-Popout/main/module.json).
 
 ## Functionality
 
@@ -25,6 +26,10 @@ formatting, and testing setup.
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+## Releases
+
+Published releases include `module.json` so Foundry can install the module directly from the manifest URL above.
 
 
 # PF2e Popout

--- a/module.json
+++ b/module.json
@@ -1,0 +1,15 @@
+{
+  "id": "pf2e-popout",
+  "title": "PF2e Popout",
+  "description": "Adds a monitor icon button to PF2e actor sheets, the combat tracker, and journal sheets.",
+  "version": "0.1.0",
+  "authors": [
+    { "name": "PF2e Popout Contributors" }
+  ],
+  "systems": ["pf2e"],
+  "esmodules": ["popout.js", "src/popout-buttons.js"],
+  "manifest": "https://raw.githubusercontent.com/yourname/PF2e-Popout/main/module.json",
+  "download": "https://github.com/yourname/PF2e-Popout/releases/download/v0.1.0/module.zip",
+  "minimumCoreVersion": "11",
+  "compatibleCoreVersion": "11"
+}


### PR DESCRIPTION
## Summary
- add module.json manifest for Foundry VTT
- document manifest URL in README and changelog
- enable browser globals in ESLint config

## Testing
- `npx @foundryvtt/foundryvtt-cli manifest validate module.json`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d36904e08327893ae3cddd5f6265