### PR TITLE
Use render API fallback when popOut is missing

### DIFF
--- a/src/popout-buttons.js
+++ b/src/popout-buttons.js
@@ -9,17 +9,22 @@ const ICON_HTML = '<i class="fas fa-tv"></i>';
 function addPopoutButton(app, html) {
   const titleElement = html.closest('.app').find('header .window-title');
   const buttonClass = 'popout-header-button';
-  if (titleElement.length === 0 || titleElement.siblings(`.${buttonClass}`).length) {
+  if (
+    titleElement.length === 0 ||
+    titleElement.siblings(`.${buttonClass}`).length
+  ) {
     return;
   }
 
-  const button = $(`<a class="${buttonClass}" title="Pop out">${ICON_HTML}</a>`);
-  button.on('click', event => {
+  const button = $(
+    `<a class="${buttonClass}" title="Pop out">${ICON_HTML}</a>`,
+  );
+  button.on('click', (event) => {
     event.preventDefault();
     if (typeof app.popOut === 'function') {
       app.popOut();
     } else {
-      app.render(true, { popout: true });
+      app.render({ force: true }, { popout: true });
     }
   });
 
@@ -31,5 +36,4 @@ function addPopoutButton(app, html) {
   }
 }
 
-HOOKS.forEach(hook => Hooks.on(hook, addPopoutButton));
-
+HOOKS.forEach((hook) => Hooks.on(hook, addPopoutButton));


### PR DESCRIPTION
## Summary
- ensure popout button uses `app.render({ force: true }, { popout: true })` when `app.popOut` is unavailable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d7a2d8388327aee377c331057ebc