### PR TITLE
refactor: remove jQuery from popout buttons

### DIFF
--- a/src/popout-buttons.js
+++ b/src/popout-buttons.js
@@ -7,14 +7,22 @@ const HOOKS = [
 const ICON_HTML = '<i class="fas fa-tv"></i>';
 
 function addPopoutButton(app, html) {
-  const titleElement = html.closest('.app').find('header .window-title');
-  const buttonClass = 'popout-header-button';
-  if (titleElement.length === 0 || titleElement.siblings(`.${buttonClass}`).length) {
+  const appElement = html[0] && html[0].closest('.app');
+  if (!appElement) {
     return;
   }
 
-  const button = $(`<a class="${buttonClass}" title="Pop out">${ICON_HTML}</a>`);
-  button.on('click', event => {
+  const buttonClass = 'popout-header-button';
+  const titleElement = appElement.querySelector('header .window-title');
+  if (!titleElement || titleElement.parentElement.querySelector(`.${buttonClass}`)) {
+    return;
+  }
+
+  const button = document.createElement('a');
+  button.classList.add(buttonClass);
+  button.title = 'Pop out';
+  button.innerHTML = ICON_HTML;
+  button.addEventListener('click', event => {
     event.preventDefault();
     if (typeof app.popOut === 'function') {
       app.popOut();
@@ -23,11 +31,11 @@ function addPopoutButton(app, html) {
     }
   });
 
-  const headerButtons = html.closest('.app').find('header .header-buttons');
-  if (headerButtons.length) {
+  const headerButtons = appElement.querySelector('header .header-buttons');
+  if (headerButtons) {
     headerButtons.prepend(button);
   } else {
-    titleElement.parent().append(button);
+    titleElement.parentElement.appendChild(button);
   }
 }
 


### PR DESCRIPTION
## Summary
- replace jQuery calls in popout button utility with DOM APIs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d7a1e7ac83278d6e633a4150fbd2