### PR TITLE
Validate message origins and restrict postMessage targets

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 let popout;
+const TRUSTED_ORIGIN = window.location.origin;
 
 document.getElementById('open-popout').addEventListener('click', () => {
   if (!popout || popout.closed) {
@@ -9,6 +10,8 @@ document.getElementById('open-popout').addEventListener('click', () => {
 });
 
 window.addEventListener('message', (event) => {
+  if (event.origin !== TRUSTED_ORIGIN) return;
+
   const log = document.getElementById('log');
   if (event.data?.type === 'roll') {
     log.innerHTML += `<p>Roll: ${event.data.result}</p>`;

--- a/popout.js
+++ b/popout.js
@@ -1,17 +1,20 @@
 const parentWindow = window.opener;
+const TRUSTED_ORIGIN = window.location.origin;
 
 document.getElementById('send-roll').addEventListener('click', () => {
   const result = Math.floor(Math.random() * 20) + 1;
-  parentWindow.postMessage({ type: 'roll', result }, '*');
+  parentWindow.postMessage({ type: 'roll', result }, TRUSTED_ORIGIN);
 });
 
 document.getElementById('send-chat').addEventListener('click', () => {
   const message = document.getElementById('chat-input').value;
-  parentWindow.postMessage({ type: 'chat', message }, '*');
+  parentWindow.postMessage({ type: 'chat', message }, TRUSTED_ORIGIN);
   document.getElementById('chat-input').value = '';
 });
 
 window.addEventListener('message', (event) => {
+  if (event.origin !== TRUSTED_ORIGIN) return;
+
   if (event.data === 'close') {
     window.close();
   }


### PR DESCRIPTION
## Summary
- validate message origins in main and popout windows
- restrict postMessage to the current origin instead of '*'

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e79d65e0832798a949944590b851