### PR TITLE
Ensure forced popout rendering with optional focus

### DIFF
--- a/src/popout-buttons.js
+++ b/src/popout-buttons.js
@@ -32,7 +32,7 @@ function addPopoutButton(app, html) {
     if (typeof app.popOut === 'function') {
       app.popOut();
     } else {
-      app.render({ force: true }, { popout: true });
+      app.render(true, { popout: true, focus: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- use boolean `force` parameter when rendering popouts
- add `focus: true` so popout windows immediately foreground

## Testing
- `npm test`
- `npm run lint`
- `npx prettier src/popout-buttons.js -w`

------
https://chatgpt.com/codex/tasks/task_e_68a8f1ebe34c83278ce41c077f8e9e81