### PR TITLE
Expose popout helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ formatting, and testing setup.
 
 ## Functionality
 
-- Exports a `popout` function from `src/index.js` that returns a message
-  indicating a pop-out was created for a given element ID.
+- Exports `savePopoutPosition` and `openPopout` from `src/index.js`. These helpers
+  store preferred window coordinates and open new windows using those saved
+  positions.
 
 ## Known Limitations
 
-- The `popout` function is a simplified example and does not create real
-  windows.
 - Only basic functionality is provided at this stage.
 
 ## License
@@ -49,7 +48,7 @@ Helpers for opening browser windows at user-defined screen coordinates.
 ## Usage
 
 ```javascript
-import { savePopoutPosition, openPopout } from './popout.js';
+import { savePopoutPosition, openPopout } from 'pf2e-popout';
 
 // Store preferred coordinates, e.g. on a second monitor.
 savePopoutPosition(1920, 100);

--- a/__tests__/exports.test.js
+++ b/__tests__/exports.test.js
@@ -1,0 +1,12 @@
+jest.mock('../popout', () => ({
+  savePopoutPosition: jest.fn(),
+  openPopout: jest.fn(),
+}));
+
+const { savePopoutPosition, openPopout } = require('../src/index');
+
+test('module re-exports helper functions', () => {
+  expect(savePopoutPosition).toBeDefined();
+  expect(openPopout).toBeDefined();
+});
+

--- a/__tests__/popout.test.js
+++ b/__tests__/popout.test.js
@@ -1,5 +1,0 @@
-const { popout } = require('../src/index');
-
-test('popout returns message', () => {
-  expect(popout('example')).toBe('Popout created for example');
-});

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
-function popout(elementId) {
-  return `Popout created for ${elementId}`;
-}
+const { savePopoutPosition, openPopout } = require('../popout');
 
-module.exports = { popout };
+module.exports = {
+  /** Store preferred pop-out window coordinates. */
+  savePopoutPosition,
+  /** Open a window using stored coordinates with fallback logic. */
+  openPopout,
+};
+


### PR DESCRIPTION
## Summary
- re-export `savePopoutPosition` and `openPopout`
- document new helper API and usage
- add test covering exported helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f5097e9c83279f2ca17b17c6df5a