### PR TITLE
feat: support dual-screen popout windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ savePopoutPosition(1920, 100);
 openPopout('https://example.com', { width: 600, height: 400 });
 ```
 
-`openPopout` verifies that the saved `left`/`top` fit within the current
-available screen space. If the target monitor is not connected, the window
-falls back to the primary screen.
+`openPopout` verifies that the saved `left`/`top` fall within the overall
+available desktop space, allowing negative or large coordinates for monitors
+positioned to the left, right, above, or below the primary display. If the
+target monitor is not connected, the window falls back to the primary screen.
 

--- a/__tests__/open-popout.test.js
+++ b/__tests__/open-popout.test.js
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+
+const { openPopout, savePopoutPosition } = require('../popout.js');
+
+beforeEach(() => {
+  window.open = jest.fn();
+  Object.defineProperty(window, 'screen', {
+    value: { availWidth: 3840, availHeight: 2160, availLeft: 0, availTop: 0 },
+    configurable: true,
+  });
+  localStorage.clear();
+});
+
+test('uses negative coordinates within bounds', () => {
+  savePopoutPosition(-100, 50);
+  openPopout('about:blank', { width: 600, height: 400 });
+  expect(window.open).toHaveBeenCalledWith(
+    'about:blank',
+    '',
+    'left=-100,top=50,width=600,height=400'
+  );
+});
+
+test('falls back when coordinates are outside available area', () => {
+  savePopoutPosition(5000, 50);
+  openPopout('about:blank', { width: 600, height: 400, left: 10, top: 20 });
+  expect(window.open).toHaveBeenCalledWith(
+    'about:blank',
+    '',
+    'left=10,top=20,width=600,height=400'
+  );
+});

--- a/popout.js
+++ b/popout.js
@@ -38,7 +38,7 @@ const STORAGE_KEY = 'pf2e-popout-coordinates';
  * @param {number} left - The x-coordinate of the window.
  * @param {number} top - The y-coordinate of the window.
  */
-export function savePopoutPosition(left, top) {
+function savePopoutPosition(left, top) {
   if (typeof left !== 'number' || typeof top !== 'number') return;
   const data = { left, top };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
@@ -59,7 +59,7 @@ export function savePopoutPosition(left, top) {
  * @param {number} [options.top] - Fallback top coordinate.
  * @returns {Window|null} - Reference to the opened window or null on failure.
  */
-export function openPopout(url, options = {}) {
+function openPopout(url, options = {}) {
   const stored = localStorage.getItem(STORAGE_KEY);
   let left, top;
   if (stored) {
@@ -72,6 +72,10 @@ export function openPopout(url, options = {}) {
 
   const availWidth = window.screen?.availWidth ?? window.innerWidth;
   const availHeight = window.screen?.availHeight ?? window.innerHeight;
+  const availLeft = window.screen?.availLeft ?? 0;
+  const availTop = window.screen?.availTop ?? 0;
+  const availRight = availLeft + availWidth;
+  const availBottom = availTop + availHeight;
 
   const defaultWidth = 600;
   const defaultHeight = 400;
@@ -81,19 +85,22 @@ export function openPopout(url, options = {}) {
   if (
     typeof left !== 'number' ||
     typeof top !== 'number' ||
-    left < 0 ||
-    top < 0 ||
-    left > availWidth ||
-    top > availHeight ||
-    left + width > availWidth ||
-    top + height > availHeight
+    left + width < availLeft ||
+    top + height < availTop ||
+    left > availRight ||
+    top > availBottom
   ) {
     // Fallback to provided options or origin screen if coordinates are invalid.
-    left = options.left ?? 0;
-    top = options.top ?? 0;
+    left = options.left ?? availLeft;
+    top = options.top ?? availTop;
   }
 
   const features = [`left=${left}`, `top=${top}`, `width=${width}`, `height=${height}`];
 
   return window.open(url, options.name ?? '', features.join(','));
 }
+
+module.exports = {
+  savePopoutPosition,
+  openPopout,
+};


### PR DESCRIPTION
## Summary
- support multi-monitor coordinates with automatic fallback when off-screen
- document dual-screen popout usage and convert helpers to CommonJS
- add tests for negative positions and fallback behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8fd93708327a6fcb62682fd18b2