### PR TITLE
Clone styles into popout head

### DIFF
--- a/scripts/popout.js
+++ b/scripts/popout.js
@@ -14,7 +14,9 @@ function openPopout(app) {
   if (!win) return;
 
   // Übernimmt CSS/Fonts des Hauptfensters
-  win.document.head.innerHTML = document.head.innerHTML;
+  document.head
+    .querySelectorAll('link[rel="stylesheet"], style')
+    .forEach((el) => win.document.head.append(el.cloneNode(true)));
 
   // Rendert eine neue Sheet-Instanz im Popout-Fenster
   const popSheet = new app.constructor(app.object, { popOut: false });


### PR DESCRIPTION
## Summary
- Clone stylesheet links and inline styles into popout window instead of copying full head HTML

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac282c34348327b88c35f173444922